### PR TITLE
Add editorUrl verification

### DIFF
--- a/src/getEditorNamespace.js
+++ b/src/getEditorNamespace.js
@@ -29,7 +29,7 @@ let promise;
  *		console.log( CKEDITOR.version );
  * } );
  * ```
- * 
+ *
  * @param {String} editorURL
  * @param {Function} onNamespaceLoaded
  * @returns {Promise}
@@ -39,7 +39,7 @@ export default function getEditorNamespace( editorURL, onNamespaceLoaded ) {
 		return Promise.resolve( CKEDITOR );
 	}
 
-	if ( editorURL.length < 1 ) {
+	if ( typeof editorURL !== 'string' || editorURL.length < 1 ) {
 		return Promise.reject( new TypeError( 'CKEditor URL must be a non-empty string.' ) );
 	}
 

--- a/tests/getEditorNamespace.js
+++ b/tests/getEditorNamespace.js
@@ -59,6 +59,27 @@ describe( 'getEditorNamespace', () => {
 		} );
 	} );
 
+	it( 'when undefined passed should throw', () => {
+		return getEditorNamespace( undefined ).catch( err => {
+			expect( err ).to.be.an( 'error' );
+			expect( err.message ).to.equal( 'CKEditor URL must be a non-empty string.' );
+		} );
+	} );
+
+	it( 'when null passed should throw', () => {
+		return getEditorNamespace( null ).catch( err => {
+			expect( err ).to.be.an( 'error' );
+			expect( err.message ).to.equal( 'CKEditor URL must be a non-empty string.' );
+		} );
+	} );
+
+	it( 'when 1 passed should throw', () => {
+		return getEditorNamespace( 1 ).catch( err => {
+			expect( err ).to.be.an( 'error' );
+			expect( err.message ).to.equal( 'CKEditor URL must be a non-empty string.' );
+		} );
+	} );
+
 	describe( 'when namespace is present', () => {
 		beforeEach( () => {
 			window.CKEDITOR = {};


### PR DESCRIPTION
Add `editorUrl` verification as string.

The old version tries to load script even with `undefined`, `null` or Number.

Based on `ckeditor4-react` getEditorNamespace [https://github.com/ckeditor/ckeditor4-react/blob/1fc3c4ebadce7b79cae4ab3fa68e53b3b08a66fd/src/getEditorNamespace.js#L11](https://github.com/ckeditor/ckeditor4-react/blob/1fc3c4ebadce7b79cae4ab3fa68e53b3b08a66fd/src/getEditorNamespace.js#L11)

Closes #16