### PR TITLE
Lock gh actions versions in CI Pipelines

### DIFF
--- a/.github/workflows/setup-workflows.yml
+++ b/.github/workflows/setup-workflows.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
       - name: Checkout default branch
         # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
         with:
           token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
 
       - name: Checkout common workflows repository
         # https://github.com/marketplace/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 #v2
         with:
           path: ckeditor4-workflows-common
           repository: ckeditor/ckeditor4-workflows-common
@@ -49,7 +49,7 @@ jobs:
       - name: Push changes
         if: env.HAS_CHANGES == 1
         # https://github.com/marketplace/actions/github-push
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@4cc74773234f74829a8c21bc4d69dd4be9cfa599 #v1.0.0
         with:
           github_token: ${{ secrets.GH_WORKFLOWS_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
```
Lock gh actions versions in CI Pipelines

This PR gh actions (exact sha) versions in CI Pipelines.

Recent supply chain attacks in popular tools (Trivy, LiteLLM, axios) are 
concerning. There might be more such attacks.

Most of our CI pipelines that use public actions (in case of Github 
Actions workflows) or CircleCI orbs are not locked versions. This means 
that if any of these packages would be released and would be vulnerable, 
our jobs would pull these vulnerable versions. We need to lock the versions to 
protect ourselfs from these kind of attacks.

The sha commits in PR can be resolved and verified in the following way:

there are lightweight tags and they point directly to a sha commit, 
so we can use the sha of the tag itself.

But there are also annotated tags, which are separate git objects and 
they are pointing to commit and have their own sha different from commit.
 
Get the SHA commit for example for configure-aws-credentials@v4:
git ls-remote https://github.com/aws-actions/configure-aws-credentials refs/tags/v4^{}
result

^{} - is automatically derefrerrencing annotated tag to commit SHA, if
result is empty then the tag is not annotated but lightweight -> then:

git ls-remote https://github.com/actions/setup-node refs/tags/v4

gives you the commit sha directly but for 
configure-aws-credentials@v4
git ls-remote https://github.com/aws-actions/configure-aws-credentials refs/tags/v4
gives us the sha of the tag itself, not the commit. 
That's why we need to try dereference the tag first and dereference is 
empty then sha of tag is sha of commit itself. So verification:
1) if 
git ls-remote https://github.com/<org>/<action> refs/tags/<version>^{}
gives result, use it, if not, then:
2) git ls-remote https://github.com/<org>/<action> refs/tags/<version>
use this result.

Touches: https://tiugotech.atlassian.net/browse/TD-1704
```
Touches: https://tiugotech.atlassian.net/browse/TD-1704

